### PR TITLE
fix: pin github actions from version to hash

### DIFF
--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.actor == 'robot-charts' || github.event_name == 'workflow_dispatch' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
       - name: get latest tag
@@ -41,23 +41,23 @@ jobs:
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
       - name: checkout latest tag
         run: git checkout ${{ steps.tag.outputs.tag }}
-      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
         with:
           platforms: 'arm64'
-      - uses: docker/setup-buildx-action@v3
-      - uses: docker/login-action@v3.0.0
+      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+      - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - id: meta
-        uses: docker/metadata-action@v5.0.0
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=raw,value=${{ steps.tag.outputs.version }}
             type=raw,value=latest
-      - uses: docker/build-push-action@v5.0.0
+      - uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
         with:
           context: .
           push: true

--- a/.github/workflows/lint-tests.yaml
+++ b/.github/workflows/lint-tests.yaml
@@ -22,29 +22,29 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.actor == 'robot-charts' || github.event_name == 'pull_request' }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 22
           cache: 'npm'
       - run: npm ci
       - run: npm run test:prepare
       - run: npm run test
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         if: github.event_name == 'pull_request'
         id: upload-artifact-report
         with:
           name: playwright-report
           path: ./test-artifacts/
           retention-days: 7
-      - uses: daun/playwright-report-summary@v3
+      - uses: daun/playwright-report-summary@1229105480a2a4bdd91598d8a146fbab41343fce # v3.11.0
         if: github.event_name == 'pull_request'
         id: report-md
         with:
           report-file: ./test-artifacts/report.json
           create-comment: false
       - name: create or update pr comment
-        uses: actions/github-script@v7
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         if: github.event_name == 'pull_request'
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -30,7 +30,7 @@ jobs:
       - cloud
       - datalens-opensource
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - run: npm run deps
         env:
           # folder in vm runner
@@ -58,7 +58,7 @@ jobs:
           STORAGE_BUCKET: ${{ vars.PREVIEW_S3_BUCKET }}
           STORAGE_PREFIX: ${{ env.INPUT_PATH }}
           HTML_ENDPOINT: ${{ vars.PREVIEW_HTML_ENDPOINT }}
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         id: upload-artifact
         if: github.event_name == 'pull_request'
         with:
@@ -66,7 +66,7 @@ jobs:
           path: ./build/${{ env.REPOSITORY_NAME }}/${{ github.event.pull_request.number || github.ref_name }}/${{ env.INPUT_PATH }}
           retention-days: 7
       - name: create or update pr comment
-        uses: actions/github-script@v7
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         if: github.event_name == 'pull_request'
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,10 +21,10 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.actor == 'robot-charts' || github.event_name == 'workflow_dispatch' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 20
           cache: 'npm'
@@ -47,16 +47,16 @@ jobs:
           npm run build
           npm run build:fix
           npm run build:api
-      - uses: thedoctor0/zip-release@0.7.1
+      - uses: thedoctor0/zip-release@b57d897cb5d60cb78b51a507f63fa184cfe35554 # 0.7.6
         with:
           type: zip
           filename: datalens-docs-${{ steps.tag.outputs.version }}.zip
           directory: build
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: datalens-docs-${{ steps.tag.outputs.version }}
           path: datalens-docs-${{ steps.tag.outputs.version }}.zip
-      - uses: ncipollo/release-action@v1
+      - uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
         with:
           artifacts: build/datalens-docs-${{ steps.tag.outputs.version }}.zip
           name: ${{ steps.tag.outputs.tag }}

--- a/.github/workflows/up-version.yml
+++ b/.github/workflows/up-version.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.actor != 'robot-charts' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           token: ${{ secrets.GH_TOKEN }}
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 20
           cache: 'npm'


### PR DESCRIPTION
Этот PR заменяет ссылки на версии GitHub Actions на конкретные коммиты для улучшения безопасности.